### PR TITLE
Prevent xml2json double-encoding/escaping some characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+### v0.2.1
+- Prevent xml2json double-escaping <>()#&" and ' (@shackpank)
+
 ### v0.2.0
 - SOAP 1.1 support (@shackpank)
 - Send empty tags on request support (@rahulpatel)

--- a/lib/serviceProvider.js
+++ b/lib/serviceProvider.js
@@ -81,7 +81,10 @@ function handleSoapResponse(method, outputModel, startTime, err, body, callback)
   if (coreSettings.createMock) saveMock(method, body);
   var json = {};
   try {
-    json = JSON.parse(parser.toJson(body));
+    json = parser.toJson(body, {
+      object: true,
+      sanitize: false
+    });
     if (coreSettings.debugSoap) console.log("JSON Response:", JSON.stringify(json, null, 2));
     json = json['soap:Envelope']['soap:Body'][method+"Response"];
     if (json == undefined) return callback("Invalid response to "+method);

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Oliver Rumbelow <oliver.rumbelow@holidayextras.com> (http://www.holidayextras.co.uk/)",
   "name": "wsdl2.js",
   "description": "Consumes a WSDL file and produces a high quality, manageable Javascript library",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/holidayextras/wsdl2.js.git"


### PR DESCRIPTION
I'm surprised at [this default behaviour](https://github.com/buglabs/node-xml2json#options-object), presumably it's to help the parser not fall over when consuming a service that outputs crappy/barely-valid/invalid xml.

I'd expect the services you'd use this library on not to do that as they've had to provide a valid WSDL.

As a bonus very minor speed improvement, this also has the library give us an object, rather than [stringifying it to pass it to us](https://github.com/buglabs/node-xml2json/blob/master/lib/xml2json.js#L192), only for us to immediately parse it again.

![tumblr_n653zgjro71s02vreo1_400](https://cloud.githubusercontent.com/assets/655660/6040571/45eed764-ac6b-11e4-9245-f82f0ce1f47b.gif)