### PR TITLE
Configurable timeouts and logstreams

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: node_js
+node_js: 0.10
+install: npm install
+cache:
+  directories:
+  - node_modules
+script:
+- npm test
+branches:
+  only:
+  - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: node_js
-node_js: 0.10
+node_js:
+  - 0.10
+  - 0.12
 install: npm install
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: node_js
 node_js:
-  - 0.10
-  - 0.12
+  - "0.10"
+  - "0.12"
+  - iojs
 install: npm install
 cache:
   directories:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v0.3.0
+- Allow changing the default timeout value (@shackpank)
+- Allow changing the default log output (@shackpank)
+
 ### v0.2.1
 - Prevent xml2json double-escaping <>()#&" and ' (@shackpank)
 

--- a/README.md
+++ b/README.md
@@ -136,10 +136,19 @@ someRequest.request(function(err, response) {
 ```javascript
 var Service = require("path/to/generated/code");
 
+// This next statement will change the duration (in milliseconds)
+// the library will wait for the service to respond before timing
+// out. The default is 15000 (15 seconds)
+Service.Settings.timeout = 5000;
+
 // This next statement will enable debugging for ALL soap requests
 // It prints to stdout JSON objects, XML documents, etc
 // default: false
 Service.Settings.debugSoap = true;
+
+// This next statement will change where the library's debugging
+// output gets written to. (The default is STDOUT)
+Service.Settings.logger = fs.createWriteStream('./test').write;
 
 // This next statement will enable benchmarking for ALL soap requests
 // It prints to stdout the name of each request and its duration in ms

--- a/lib/serviceProvider.js
+++ b/lib/serviceProvider.js
@@ -201,7 +201,7 @@ function SoapService() {
               coreSettings.logger("JSON:", JSON.stringify(this, null, 2));
               coreSettings.logger("XML: ", this.preview());
               coreSettings.logger("Validates:", this.validate());
-              coreSettings.logger("--------------------coreSettings.logger----");
+              coreSettings.logger("------------------------");
             };
             Object.defineProperty(this, "debug", { enumerable: false });
             Object.preventExtensions(this);

--- a/lib/serviceProvider.js
+++ b/lib/serviceProvider.js
@@ -28,7 +28,8 @@ var coreSettings = {
   benchmark: true,
   createMock: false,
   useMock: false,
-  modeler: Modeler.Settings
+  modeler: Modeler.Settings,
+  logger: console.log
 };
 
 function jsonToXml(data, name) {
@@ -72,9 +73,9 @@ function loadMock(method, callback) {
 };
 
 function handleSoapResponse(method, outputModel, startTime, err, body, callback) {
-  if (coreSettings.benchmark) console.log("SOAP", method, "took:", (new Date())-startTime);
-  if (coreSettings.debugSoap) console.log("Error:", err);
-  if (coreSettings.debugSoap) console.log("Response:", body);
+  if (coreSettings.benchmark) coreSettings.logger("SOAP", method, "took:", (new Date())-startTime);
+  if (coreSettings.debugSoap) coreSettings.logger("Error:", err);
+  if (coreSettings.debugSoap) coreSettings.logger("Response:", body);
   if (err) {
     return callback(err, null);
   }
@@ -85,19 +86,19 @@ function handleSoapResponse(method, outputModel, startTime, err, body, callback)
       object: true,
       sanitize: false
     });
-    if (coreSettings.debugSoap) console.log("JSON Response:", JSON.stringify(json, null, 2));
+    if (coreSettings.debugSoap) coreSettings.logger("JSON Response:", JSON.stringify(json, null, 2));
     json = json['soap:Envelope']['soap:Body'][method+"Response"];
     if (json == undefined) return callback("Invalid response to "+method);
     obj = new models[outputModel](json);
-    if (coreSettings.debugSoap) console.log("Output:", JSON.stringify(json, null, 2));
+    if (coreSettings.debugSoap) coreSettings.logger("Output:", JSON.stringify(json, null, 2));
 
     obj.debug = function() {
-      console.log("----", method+" Response", "----");
-      console.log("XML: ", body);
-      console.log("JSON:", JSON.stringify(json, null, 2));
-      console.log("Modeled:", JSON.stringify(obj, null, 2));
-      console.log("Validates:", obj.validate());
-      console.log("------------------------");
+      coreSettings.logger("----", method+" Response", "----");
+      coreSettings.logger("XML: ", body);
+      coreSettings.logger("JSON:", JSON.stringify(json, null, 2));
+      coreSettings.logger("Modeled:", JSON.stringify(obj, null, 2));
+      coreSettings.logger("Validates:", obj.validate());
+      coreSettings.logger("------------------------");
     };
     Object.defineProperty(obj, "debug", { enumerable: false });
     Object.preventExtensions(this);
@@ -127,12 +128,12 @@ function doSoapRequest(url, method, soapAction, data, inputModel, outputModel, n
     url: url,
     headers: headers,
     body: soapBody,
-    timeout: 15000
+    timeout: coreSettings.timeout || 15000
   };
 
-  if (coreSettings.debugSoap) console.log("\n####", method, "Request ####");
-  if (coreSettings.debugSoap) console.log("Input:", JSON.stringify(data, null, 2));
-  if (coreSettings.debugSoap) console.log("Request:", JSON.stringify(soapRequest, null, 2));
+  if (coreSettings.debugSoap) coreSettings.logger("\n####", method, "Request ####");
+  if (coreSettings.debugSoap) coreSettings.logger("Input:", JSON.stringify(data, null, 2));
+  if (coreSettings.debugSoap) coreSettings.logger("Request:", JSON.stringify(soapRequest, null, 2));
   if (coreSettings.benchmark) startTime = new Date();
   if (!coreSettings.useMock) {
     request.post(soapRequest, function (err, response, body) {
@@ -196,11 +197,11 @@ function SoapService() {
             };
             Object.defineProperty(this, "preview", { enumerable: false });
             this.debug = function() {
-              console.log("----", functionName+" Request", "----");
-              console.log("JSON:", JSON.stringify(this, null, 2));
-              console.log("XML: ", this.preview());
-              console.log("Validates:", this.validate());
-              console.log("------------------------");
+              coreSettings.logger("----", functionName+" Request", "----");
+              coreSettings.logger("JSON:", JSON.stringify(this, null, 2));
+              coreSettings.logger("XML: ", this.preview());
+              coreSettings.logger("Validates:", this.validate());
+              coreSettings.logger("--------------------coreSettings.logger----");
             };
             Object.defineProperty(this, "debug", { enumerable: false });
             Object.preventExtensions(this);

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Oliver Rumbelow <oliver.rumbelow@holidayextras.com> (http://www.holidayextras.co.uk/)",
   "name": "wsdl2.js",
   "description": "Consumes a WSDL file and produces a high quality, manageable Javascript library",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/holidayextras/wsdl2.js.git"


### PR DESCRIPTION
_Hopefully_ the first option won't be needed, but I've added it as it was fairly simple.

The second option will allow redirecting debug output to a file, which we like doing in non-development environments.

I've added tests for the new options, maybe the travis.yml I've added will make them run (and pass)...

![burperu](https://cloud.githubusercontent.com/assets/655660/6215906/cc3e3194-b5fc-11e4-9d55-8222c331e376.gif)
