### PR TITLE
Better debug output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+### v0.4.0
+- Send an object containing all request and response information to the logger (@rahulpatel)
+
 ### v0.3.0
 - Allow changing the default timeout value (@shackpank)
 - Allow changing the default log output (@shackpank)

--- a/README.md
+++ b/README.md
@@ -142,13 +142,18 @@ var Service = require("path/to/generated/code");
 Service.Settings.timeout = 5000;
 
 // This next statement will enable debugging for ALL soap requests
-// It prints to stdout JSON objects, XML documents, etc
+// It'll print out the request start and end times, how long the
+// request took, xml that was sent and recieved as well as the
+// json recieved and the output provided by the library
 // default: false
 Service.Settings.debugSoap = true;
 
-// This next statement will change where the library's debugging
-// output gets written to. (The default is STDOUT)
-Service.Settings.logger = fs.createWriteStream('./test').write;
+// This next statement allows you to override the default (stdout) logging
+// provided by wsdl2.js. The function will recieve a json object.
+// default: stdout
+Service.Settings.logger = function(data) {
+  fs.createWriteStream('./test').write(JSON.stringify(data));
+};
 
 // This next statement will enable benchmarking for ALL soap requests
 // It prints to stdout the name of each request and its duration in ms
@@ -173,7 +178,7 @@ additionRequest.request(function(err, response) {
   if (err || !response) {
     return callback(err || "No response?");
   }
-  
+
   //... w00p!
 });
 ```

--- a/lib/serviceProvider.js
+++ b/lib/serviceProvider.js
@@ -149,8 +149,6 @@ function doSoapRequest(url, method, soapAction, data, inputModel, outputModel, n
       request: soapRequest
     }
   };
-  if (coreSettings.debugSoap) coreSettings.logger(debug);
-
   if (!coreSettings.useMock) {
     request.post(soapRequest, function (err, response, body) {
       handleSoapResponse(method, outputModel, err, body, callback, debug);

--- a/lib/serviceProvider.js
+++ b/lib/serviceProvider.js
@@ -29,7 +29,9 @@ var coreSettings = {
   createMock: false,
   useMock: false,
   modeler: Modeler.Settings,
-  logger: console.log
+  logger: function(data) {
+    console.log(JSON.stringify(data, null, 2));
+  }
 };
 
 function jsonToXml(data, name) {
@@ -72,11 +74,17 @@ function loadMock(method, callback) {
   fs.readFile(__dirname+'/Mocks/'+method+".js", callback);
 };
 
-function handleSoapResponse(method, outputModel, startTime, err, body, callback) {
-  if (coreSettings.benchmark) coreSettings.logger("SOAP", method, "took:", (new Date())-startTime);
-  if (coreSettings.debugSoap) coreSettings.logger("Error:", err);
-  if (coreSettings.debugSoap) coreSettings.logger("Response:", body);
+function handleSoapResponse(method, outputModel, err, body, callback, debug) {
+  debug.endTime = new Date();
+  debug.took = (debug.endTime)-(debug.startTime);
+  debug.response = {
+    error: err,
+    response: body
+  };
+  if (coreSettings.benchmark) coreSettings.logger({ method: method, took: debug.took });
+
   if (err) {
+    if (coreSettings.debugSoap) coreSettings.logger(debug);
     return callback(err, null);
   }
   if (coreSettings.createMock) saveMock(method, body);
@@ -86,19 +94,23 @@ function handleSoapResponse(method, outputModel, startTime, err, body, callback)
       object: true,
       sanitize: false
     });
-    if (coreSettings.debugSoap) coreSettings.logger("JSON Response:", JSON.stringify(json, null, 2));
+
     json = json['soap:Envelope']['soap:Body'][method+"Response"];
     if (json == undefined) return callback("Invalid response to "+method);
     obj = new models[outputModel](json);
-    if (coreSettings.debugSoap) coreSettings.logger("Output:", JSON.stringify(json, null, 2));
+
+    debug.response.output = json;
+    if (coreSettings.debugSoap) coreSettings.logger(debug);
 
     obj.debug = function() {
-      coreSettings.logger("----", method+" Response", "----");
-      coreSettings.logger("XML: ", body);
-      coreSettings.logger("JSON:", JSON.stringify(json, null, 2));
-      coreSettings.logger("Modeled:", JSON.stringify(obj, null, 2));
-      coreSettings.logger("Validates:", obj.validate());
-      coreSettings.logger("------------------------");
+      coreSettings.logger({
+        method: method,
+        type: 'Response',
+        xml: body,
+        json: json,
+        modeled: obj,
+        validates: obj.validate()
+      });
     };
     Object.defineProperty(obj, "debug", { enumerable: false });
     Object.preventExtensions(this);
@@ -115,7 +127,6 @@ function doSoapRequest(url, method, soapAction, data, inputModel, outputModel, n
     'SOAPAction': '"'+soapAction+'"'
   };
 
-  var startTime;
   var soapBody = '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">' +
                    '<soap:Body>' +
                      '<'+method+' xmlns="'+ns+'">'+
@@ -130,18 +141,23 @@ function doSoapRequest(url, method, soapAction, data, inputModel, outputModel, n
     body: soapBody,
     timeout: coreSettings.timeout || 15000
   };
+  var debug = {
+    startTime: new Date(),
+    request: {
+      method: method,
+      input: data,
+      request: soapRequest
+    }
+  };
+  if (coreSettings.debugSoap) coreSettings.logger(debug);
 
-  if (coreSettings.debugSoap) coreSettings.logger("\n####", method, "Request ####");
-  if (coreSettings.debugSoap) coreSettings.logger("Input:", JSON.stringify(data, null, 2));
-  if (coreSettings.debugSoap) coreSettings.logger("Request:", JSON.stringify(soapRequest, null, 2));
-  if (coreSettings.benchmark) startTime = new Date();
   if (!coreSettings.useMock) {
     request.post(soapRequest, function (err, response, body) {
-      handleSoapResponse(method, outputModel, startTime, err, body, callback)
+      handleSoapResponse(method, outputModel, err, body, callback, debug);
     });
   } else {
     loadMock(method, function(err, body) {
-      handleSoapResponse(method, outputModel, startTime, err, body, callback)
+      handleSoapResponse(method, outputModel, err, body, callback, debug);
     });
   }
 };
@@ -197,11 +213,13 @@ function SoapService() {
             };
             Object.defineProperty(this, "preview", { enumerable: false });
             this.debug = function() {
-              coreSettings.logger("----", functionName+" Request", "----");
-              coreSettings.logger("JSON:", JSON.stringify(this, null, 2));
-              coreSettings.logger("XML: ", this.preview());
-              coreSettings.logger("Validates:", this.validate());
-              coreSettings.logger("------------------------");
+              coreSettings.logger({
+                method: functionName,
+                type: 'Request',
+                json: this,
+                xml: this.preview(),
+                validates: this.validate()
+              });
             };
             Object.defineProperty(this, "debug", { enumerable: false });
             Object.preventExtensions(this);

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Oliver Rumbelow <oliver.rumbelow@holidayextras.com> (http://www.holidayextras.co.uk/)",
   "name": "wsdl2.js",
   "description": "Consumes a WSDL file and produces a high quality, manageable Javascript library",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/holidayextras/wsdl2.js.git"

--- a/tests/test.js
+++ b/tests/test.js
@@ -61,7 +61,7 @@ var tests = {
     assert.equal(params.timeout, 35000);
   },
   'Check library with debugging logs to standard out': function() {
-    sandbox.stub(request, 'post');
+    sandbox.stub(request, 'post').yields(null, { }, { });
     sandbox.stub(process.stdout, 'write');
 
     var params = {
@@ -75,7 +75,7 @@ var tests = {
     assert.ok(process.stdout.write.called);
   },
   'Check library with debugging logs to custom stream': function() {
-    sandbox.stub(request, 'post');
+    sandbox.stub(request, 'post').callsArgWith(1, null, { }, { });
 
     var params = {
       ActivateLicense: new Service.Types.ActivateLicenseType({ licenseId: 'foo', capacity: 1 })

--- a/tests/test.js
+++ b/tests/test.js
@@ -75,7 +75,7 @@ var tests = {
     assert.ok(process.stdout.write.called);
   },
   'Check library with debugging logs to custom stream': function() {
-    sandbox.stub(request, 'post').callsArgWith(1, null, { }, { });
+    sandbox.stub(request, 'post').yields(null, { }, { });
 
     var params = {
       ActivateLicense: new Service.Types.ActivateLicenseType({ licenseId: 'foo', capacity: 1 })


### PR DESCRIPTION
The debug output is pretty printing the json output which isn't ideal when you're trying to write to log files in environments other than development. So this change hands the pretty printing responsibility over to the logging function. The library itself will pass the logging function an object containing the same information it was logging individually.
