### PR TITLE
use synchronous write to avoid passing callbacks

### DIFF
--- a/wsdl2.js
+++ b/wsdl2.js
@@ -94,15 +94,15 @@ function processWSDL(json) {
   processTypes(json);
 
   var serviceDefinition = "module.exports = "+JSON.stringify(services,null,2);
-  fs.writeFile(process.cwd()+"/"+serviceName+'/ServiceDefinition.js', serviceDefinition);
+  fs.writeFileSync(process.cwd()+"/"+serviceName+'/ServiceDefinition.js', serviceDefinition);
 
   var modelerFile = fs.readFileSync(__dirname+"/lib/Modeler.js");
-  fs.writeFile(process.cwd()+"/"+serviceName+'/Modeler.js', modelerFile);
+  fs.writeFileSync(process.cwd()+"/"+serviceName+'/Modeler.js', modelerFile);
 
   var indexFile = fs.readFileSync(__dirname+"/lib/serviceProvider.js", 'utf8');
   indexFile = indexFile.replace("###1###", contentTypeHeaders[soapVersion]);
   indexFile = indexFile.replace('###2###', keepEmptyTags);
-  fs.writeFile(process.cwd()+"/"+serviceName+'/index.js', indexFile);
+  fs.writeFileSync(process.cwd()+"/"+serviceName+'/index.js', indexFile);
 };
 
 /*****************************************


### PR DESCRIPTION
Hello,
I would like to propose you this PR to fix an issue I faced with node 10.11.0. 
Here is the result I had before my modification: 
```
fs.js:129
  throw new ERR_INVALID_CALLBACK();
  ^

TypeError [ERR_INVALID_CALLBACK]: Callback must be a function
    at maybeCallback (fs.js:129:9)
    at Object.writeFile (fs.js:1137:14)
    at processWSDL (/usr/local/lib/node_modules/wsdl2.js/wsdl2.js:97:6)
    at Object.<anonymous> (/usr/local/lib/node_modules/wsdl2.js/wsdl2.js:79:1)
    at Module._compile (internal/modules/cjs/loader.js:689:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
    at Module.load (internal/modules/cjs/loader.js:599:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
    at Function.Module._load (internal/modules/cjs/loader.js:530:3)
    at Function.Module.runMain (internal/modules/cjs/loader.js:742:12)

```